### PR TITLE
Added 'position: relative;' to .lazyLoad-container class.

### DIFF
--- a/vendor/lazy-video/lazy-video.css
+++ b/vendor/lazy-video/lazy-video.css
@@ -6,6 +6,7 @@
   background-size: cover;
   background-position: center center;
   background-repeat: no-repeat;
+  position: relative;
 }
 .lazyLoad-container:hover .lazyLoad-play svg {
   fill: rgb(206,19,18);


### PR DESCRIPTION
I added `position: relative;` to the container class so that the play button is centered in the placeholder when the container is different sizes.