### PR TITLE
More friendly fastboot support

### DIFF
--- a/addon/components/lazy-video.js
+++ b/addon/components/lazy-video.js
@@ -31,7 +31,6 @@ export default Ember.Component.extend({
     var self      = this;
 
     if ( poster ) {
-      set(this, 'videoThumbnail', poster);
       return;
     }
 
@@ -40,8 +39,9 @@ export default Ember.Component.extend({
     });
   }),
 
-  style: Ember.computed('videoThumbnail', function() {
-    var thumbnail = get(this, 'videoThumbnail');
+  style: Ember.computed('videoThumbnail', 'poster', function() {
+    var poster = get(this, 'poster');
+    var thumbnail = poster || get(this, 'videoThumbnail');
     return 'background-image: url(' + thumbnail + ')';
   })
 });


### PR DESCRIPTION
I moved the ability to set the poster image out of the `didInsertElement` which is never used in FastBoot. This way fastboot can render poster images.