### PR TITLE
Fetching thumbnail when the url changes

### DIFF
--- a/addon/components/lazy-video.js
+++ b/addon/components/lazy-video.js
@@ -2,7 +2,6 @@ import Ember from 'ember';
 import { task } from 'ember-concurrency';
 
 const {
-  on,
   get,
   inject,
   set,
@@ -37,7 +36,7 @@ export default Component.extend({
     }
   },
 
-  getThumbnailTask: task(function *(url) {
+  getThumbnailTask: task(function* (url) {
     let providers = get(this, 'providers');
 
     let image = yield providers.getThumbnailUrl(url);

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "lazy load"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.7"
+    "ember-cli-babel": "^5.1.7",
+    "ember-concurrency": "0.8.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/unit/components/lazy-video-test.js
+++ b/tests/unit/components/lazy-video-test.js
@@ -26,11 +26,12 @@ moduleForComponent('lazy-video', 'LazyVideoComponent', {
 test('it renders with correct style attribute', function(assert) {
   assert.expect(1);
 
-  let component = this.subject({
-    url: 'https://www.youtube.com/watch?v=gvdf5n-zI14'
-  });
+  let component;
+  run(() => {
+    component = this.subject({
+      url: 'https://www.youtube.com/watch?v=gvdf5n-zI14'
+    });
 
-  run(function() {
     component.append();
   });
 

--- a/tests/unit/components/lazy-video-test.js
+++ b/tests/unit/components/lazy-video-test.js
@@ -27,7 +27,7 @@ test('it renders with correct style attribute', function(assert) {
   assert.expect(1);
 
   let component;
-  run(() => {
+  run(this, function() {
     component = this.subject({
       url: 'https://www.youtube.com/watch?v=gvdf5n-zI14'
     });


### PR DESCRIPTION
Thumbnails were only fetched on didInsertElement. When the URL change, the thumbnail was not refetched. This PR adds code to ensure that when the URL changes a new thumbnail is fetched. Thumbnails are fetched asynchronously, to ensure that we're always showing the last thumbnail, I added an ember-concurrency task.

- Removed on('didInsertElement', function() { ... })
- Added didReceiveAttrs hook
- Added ember-concurrency as a dependency
- Added getThumbnailTask task to fetch thumbnails
- Using getThumbnailTask in didReceiveAttrs hook
- Making sure that getThumbnailTask is only called when url changes

I didn't add a test, let me know if you'd like me to add one.