### PR TITLE
upgrade ember-cli-babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lazy load"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.7"
+    "ember-cli-babel": "^6.8.2"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
because the 5.x series is loudly deprecated.